### PR TITLE
using require.main.require

### DIFF
--- a/library.js
+++ b/library.js
@@ -1,12 +1,10 @@
-var
-
-    pluginData = require('./plugin.json'),
-    winston = module.parent.require('winston'),
-    Meta = module.parent.require('./meta'),
-    db = module.parent.require('./database'),
-    Plugin = {},
-    question = '',
-    answer = '';
+var pluginData = require('./plugin.json');
+var winston = require.main.require('winston');
+var Meta = require.main.require('./src/meta');
+var db = require.main.require('./src/database');
+var Plugin = {};
+var question = '';
+var answer = '';
 
 pluginData.nbbId = pluginData.id.replace(/nodebb-plugin-/, '');
 


### PR DESCRIPTION
this is to prevent warnings on latest version of NodeBB and Node:

`2020-05-02T19:13:00.181Z [4568/3705] - warn: [deprecated] requiring core modules with `module.parent.require('./meta'
Require stack:
- /home/nodebb/nodebb/src/plugins/index.js
- /home/nodebb/nodebb/src/groups/index.js
- /home/nodebb/nodebb/src/user/index.js
- /home/nodebb/nodebb/src/events.js
- /home/nodebb/nodebb/src/meta/themes.js
- /home/nodebb/nodebb/src/meta/index.js
- /home/nodebb/nodebb/src/start.js
- /home/nodebb/nodebb/require-main.js
- /home/nodebb/nodebb/app.js)` is deprecated. Please use `require.main.require("./src/<module_name>")` instead.
    at Object.<anonymous> (/home/nodebb/nodebb/node_modules/nodebb-plugin-anti-spam-question/library.js:5:26)`